### PR TITLE
Update README to include link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 # Yopass - Share Secrets Securely
 
+Infrastructure-as-Code (Terraform) can be found in `infrastructure`.
+
+App is released using Hopper -:
+
+[Hopper - staging](https://hopper-staging.deliveroo.net/apps/yopass#overview)
+[Hopper - production](https://hopper.deliveroo.net/apps/yopass#overview)
+
+[Deliveroo Documentation](https://deliveroo.atlassian.net/wiki/spaces/EN/pages/4782981127/Yopass+-+share+passwords+within+Deliveroo+in+a+secure+way)
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/jhaals/yopass)](https://goreportcard.com/report/github.com/jhaals/yopass)
 [![codecov](https://codecov.io/gh/jhaals/yopass/branch/master/graph/badge.svg)](https://codecov.io/gh/jhaals/yopass)
 


### PR DESCRIPTION
Update the `README` to include a link to the Confluence documentation URL.