### PR TITLE
Update Github action to sync repo with upstream

### DIFF
--- a/.github/workflows/sync-repo-with-upstream.yml
+++ b/.github/workflows/sync-repo-with-upstream.yml
@@ -26,14 +26,26 @@ jobs:
       - name: Fetch upstream changes
         run: git fetch upstream
 
-      - name: Checkout new branch
+      - name: Checkout staging branch
+        run: git checkout staging
+
+      - name: Merge upstream changes into staging excluding Dockerfile
+        run: |
+          git merge upstream/master --no-commit --no-ff --allow-unrelated-histories || true
+          git reset HEAD Dockerfile
+          git checkout -- Dockerfile
+          git add -A
+          git commit -m "Merge upstream changes into staging"
+          git push origin staging
+
+      - name: Checkout new branch for master PR
         id: checkout-new-branch
         run: |
           BRANCH_NAME="sync-upstream-$(date +%s)"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
           git checkout -b $BRANCH_NAME
 
-      - name: Merge upstream changes excluding Dockerfile
+      - name: Merge upstream changes into new branch excluding Dockerfile
         run: |
           git merge upstream/master --no-commit --no-ff --allow-unrelated-histories || true
           git reset HEAD Dockerfile
@@ -44,12 +56,12 @@ jobs:
         run: |
           git push origin $BRANCH_NAME
 
-      - name: Create Pull Request
+      - name: Create Pull Request for master
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: 'Sync with upstream'
-          branch: $BRANCH_NAME
+          branch: ${{ env.BRANCH_NAME }}
           title: 'Sync with upstream Yopass repository'
           body: |
             This PR keeps the forked repository in sync with the upstream Yopass repository
-          base: staging
+          base: master


### PR DESCRIPTION
Update the Github action which keeps this repo in sync with upstream. Auto merges to `staging` branch but will raise a PR for merging into the `master` branch.