### PR TITLE
fix gh action to sync master to staging

### DIFF
--- a/.github/workflows/sync-repo-and-raise-pr.yml
+++ b/.github/workflows/sync-repo-and-raise-pr.yml
@@ -1,4 +1,4 @@
-name: Sync with Upstream and Create PR
+name: Sync master with staging and Create PR
 
 on:
   schedule:
@@ -13,48 +13,42 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Fetch all history for all branches and tags
+          fetch-depth: 0
 
       - name: Set up Git
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-      - name: Add upstream remote
-        run: git remote add upstream https://github.com/jhaals/yopass.git
+      - name: Fetch all branches
+        run: git fetch --all
 
-      - name: Fetch upstream master
-        run: git fetch upstream master
-
-      - name: Check for changes in upstream master
-        id: check_changes
+      - name: Create a new branch from master
         run: |
-          git fetch upstream master
-          if git diff --quiet HEAD..upstream/master; then
-            echo "no changes"
-            echo "{changes}={false}" >> $GITHUB_OUTPUT
-          else
-            echo "changes detected"
-            echo "{changes}={true}" >> $GITHUB_OUTPUT
-          fi
+          git checkout master
+          git checkout -b sync/staging-to-master
 
-      - name: Sync with upstream master
-        if: steps.check_changes.outputs.changes == 'true'
+      - name: Merge Staging into the new branch
+        run: git merge --no-ff origin/staging --allow-unrelated-histories || true
+
+      - name: Revert changes to Dockerfile and .github
         run: |
-          git checkout staging
-          git merge --no-commit upstream/master
-          git restore --source=HEAD --staged --worktree Dockerfile .github
+          git checkout HEAD -- Dockerfile
+          git checkout HEAD -- .github
 
+      - name: Push changes to the new branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push -f origin sync/staging-to-master
 
-      - name: Create Pull Request to master
-        if: steps.check_changes.outputs.changes == 'true'
+      - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Merge changes from upstream master [skip ci]"
-          branch: sync-upstream-master
           base: master
+          branch: sync/staging-to-master
+          title: 'Sync Staging to Master'
           body: |
-            This PR merges changes from the upstream YoPass master branch
-          title: Merge changes from upstream master
-          team-reviewers: deliveroo/security-eng
+            This is an automated pull request to merge changes from the `staging` branch into the `master` branch.
+          commit-message: 'Sync changes from staging to master'
+          delete-branch: true


### PR DESCRIPTION
A Github action runs daily to sync with the upstream and auto release to staging, this PR syncs staging to master and raise a PR