### PR TITLE
Creating a scorecard config skeleton file to assist with scorecard setup

### DIFF
--- a/.scorecard/config.yaml
+++ b/.scorecard/config.yaml
@@ -1,0 +1,45 @@
+# Scorecard Configuration File
+
+# This is used to manually capture values for the scorecard. Over time, information in this file will be replaced by automated checks.
+# Please see https://github.com/deliveroo/service-readiness-api/blob/main/.scorecard/config.example.yml for an example configuration file.
+# Documentation: https://deliveroo.atlassian.net/wiki/spaces/SRE/pages/4827185189/Service+Scorecard+Config+File
+
+version: 1
+last_updated_at: "2024-12-10"
+
+service_scorecard:
+  # The name of the Hopper application. This should match the name used in internal systems and documentation.
+  - hopper_app_name: "<Hopper App Name>"
+
+    # 1. Basic information
+    basic_information:
+
+    # 2. Ecosystem Architecture Diagram
+    architecture_diagram:
+
+    # 3. Request Flows
+    request_flows:
+
+    # 4. Releases
+    releases:
+
+    # 5. Performance and Scalability
+    performance_scalability:
+
+    # 6. Dependencies
+    dependencies:
+
+    # 7. Recommendations and Best Practices
+    recommendations_best_practices:
+
+    # 8. Monitoring Dashboards
+    monitoring_dashboards:
+
+    # 9. Monitors and Alerts
+    monitors_alerts:
+
+    # 10. Efficiency
+    efficiency:
+
+  # If you have multiple hopper apps within one repo, please add another entry for the next app.
+  # - hopper_app_name:


### PR DESCRIPTION
# PR: Add Skeleton Scorecard Manifest File

### What is the Scorecard
The **Scorecard** is a brand new curated framework for assessing the operational maturity of an individual service against Deliveroo's engineering standards, providing a structured pathway from minimum compliance to industry excellence.

Deliveroo's manual [service readiness process](https://docs.google.com/document/d/14vwkYIBmv9YCffnJGzAxqGX44FtEI6L4gBdt2lM_Y1Q/edit?usp=sharing) has been essential in ensuring our services are production-ready. However, it has been challenging to track the readiness of all services across the organisation and can often become stale as services evolve over time. The new Scorecard revamps the existing service readiness process into a largely automated and near-real-time tracker of your service's readiness and quality metrics. We will be launching the Scorecard over the next few weeks, so keep an eye out for more information!

### Summary
Most metrics in the Scorecard are automatically evaluated, however some metrics require manual input from the owning team. This PR introduces a skeleton scorecard manifest file to the repository, allowing us to cover all aspects of the existing service readiness process and more - over time, we plan to shrink this file as we automate the evaluation of more and more Scorecard metrics.

### Action Required
Please can you review and merge the skeleton manifest file into your repo. You are *not* required to fill in any information yet, further announcements about this will occur in the coming weeks. However, if you wish to see an example of a populated scorecard manifest file, you can do so in [this example](https://github.com/deliveroo/service-readiness-api/blob/main/.scorecard/config.yml). Check out the config file [documentation](https://deliveroo.atlassian.net/wiki/spaces/SRE/pages/4827185189/Service+Scorecard+Config+File) for more information too.

⚠️ Please note that these PRs are auto-generated and there are 501 of them in total across our org, so we won't be able to respond to individual requests for bespoke changes - please go ahead and make any necessary changes needed to the file to adapt to your repo. The Scorecard engine will scan for a ```.scorecard/config.yml``` file in your repo and will automatically evaluate the information supplied in the file.

🙏 Although we've added a ```to-stage``` label for repos that are using Marvin, not all repos are using Marvin or have a unique staging process, if the latter applies to you, please stage these changes yourself

✅ If you're happy with the changes, please can you go ahead and merge after you're reviewed to help us track progress - thank you!

### Questions
If you have any questions, please reach out to us on Slack in the [Scorecards Support](https://deliveroo.slack.com/archives/C080FS9R0CU) channel.
