### PR TITLE
bump node version to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /yopass
 COPY . .
 RUN go build ./cmd/yopass && go build ./cmd/yopass-server
 
-FROM node:18 as website
+FROM node:22 as website
 COPY website /website
 WORKDIR /website
 RUN yarn install --network-timeout 600000 && yarn build


### PR DESCRIPTION
We fork YoPass, updates from upstream are pulled down except for the `Dockerfile` which we have custom config for running in Hopper.

This bumps the version of `node` for the webapp as it is currently breaking builds - https://app.circleci.com/pipelines/github/deliveroo/yopass/362