### PR TITLE
correct branch ref for gh action workflow syncs staging to master

### DIFF
--- a/.github/workflows/sync-repo-and-raise-pr.yml
+++ b/.github/workflows/sync-repo-and-raise-pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: master
       - name: Reset promotion branch
         run: |
           git fetch origin staging:staging


### PR DESCRIPTION
`checkout` action in Github action workflow to sync `staging` to `master` has an incorrect ref.