### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -102,20 +102,20 @@ func (y *Server) getSecret(w http.ResponseWriter, request *http.Request) {
 	secretKey := mux.Vars(request)["key"]
 	secret, err := y.db.Get(secretKey)
 	if err != nil {
-		y.logger.Debug("Secret not found", zap.Error(err), zap.String("key", secretKey))
+		y.logger.Debug("Secret not found", zap.Error(err))
 		http.Error(w, `{"message": "Secret not found"}`, http.StatusNotFound)
 		return
 	}
 
 	data, err := secret.ToJSON()
 	if err != nil {
-		y.logger.Error("Failed to encode request", zap.Error(err), zap.String("key", secretKey))
+		y.logger.Error("Failed to encode request", zap.Error(err))
 		http.Error(w, `{"message": "Failed to encode secret"}`, http.StatusInternalServerError)
 		return
 	}
 
 	if _, err := w.Write(data); err != nil {
-		y.logger.Error("Failed to write response", zap.Error(err), zap.String("key", secretKey))
+		y.logger.Error("Failed to write response", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/deliveroo/yopass/security/code-scanning/3](https://github.com/deliveroo/yopass/security/code-scanning/3)

To fix the problem, we should avoid logging the `secretKey` directly. Instead, we can log a message indicating the failure without including the sensitive `secretKey`. This approach maintains the functionality of logging errors while ensuring that sensitive information is not exposed.

- Remove the logging of `secretKey` in the error messages.
- Update the logging statements to exclude the `secretKey`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
